### PR TITLE
Remove the fHasNewVersion flag

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -227,8 +227,8 @@ public:
             (900000, uint256S("0x6b9457bc395353eb5f08a88229125f3f30872e0771c5bbd5436beb950e20571a"))
             (1000000, uint256S("0x003bdc5e722fda8bb52ff1f54b3fe4896bed0708274ef787de6209d6817b7edd"))
             (1087500, uint256S("0x5b03f9206287debfdfa60496481da4b994d7d3a3a7264f2dd22c8e5c9cf443a1")),
-	    1495790340, // * UNIX timestamp of last checkpoint block
-            1561119,   // * total number of transactions between genesis and last checkpoint
+            1506940111, // * UNIX timestamp of last checkpoint block
+            1656788,   // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
             1000.0     // * estimated number of transactions per day after checkpoint
         };

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -851,8 +851,6 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
             CNode* pnode = vNodes[i];
             if (pnode->fWhitelisted)
                 continue;
-            if (pnode->fHasNewVersion)
-                continue;
             if (!pnode->fInbound)
                 continue;
             if (pnode->fDisconnect)
@@ -2414,7 +2412,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nLastWarningTime = 0;
     strSubVer = "";
     fWhitelisted = false;
-    fHasNewVersion = false;
     fOneShot = false;
     fClient = false; // set by version message
     fInbound = fInboundIn;

--- a/src/net.h
+++ b/src/net.h
@@ -350,7 +350,6 @@ public:
     // the network or wire types and the cleaned string used when displayed or logged.
     std::string strSubVer, cleanSubVer;
     bool fWhitelisted; // This peer can bypass DoS banning.
-    bool fHasNewVersion; //This is a new version peer during old rules, we will strongly prefer to stay connected
     bool fOneShot;
     bool fClient;
     bool fInbound;
@@ -841,7 +840,7 @@ public:
 class CTransaction;
 void RelayTransaction(const CTransaction& tx);
 void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
-void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION_OLD);
+void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/version.h
+++ b/src/version.h
@@ -18,8 +18,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 31800;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_OLD = 70002;
-static const int MIN_PEER_PROTO_VERSION_NEW = 70206;
+static const int MIN_PEER_PROTO_VERSION = 70206;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
This flag is no longer needed to keep the network in one piece as we booted the old clients.  The other commit updates the checkpoint timestamp and tx count that I forgot to do.