### PR TITLE
Fix GetBlockHeader() to include the auxpow for sending merkle block correctly

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -116,14 +116,7 @@ public:
 
     CBlockHeader GetBlockHeader() const
     {
-        CBlockHeader block;
-        block.nVersion       = nVersion;
-        block.hashPrevBlock  = hashPrevBlock;
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
-        return block;
+        return *this;
     }
 
     // Build the in-memory merkle tree for this block and return the merkle root.


### PR DESCRIPTION
Currently the MERKLEBLOCK message is broken and makes server node crash when spv client send MSG_FILTERED_BLOCK message.
The fix will including the auxpow and resolve the assert error for not existing auxpow.